### PR TITLE
Apply reset styles to all input elements

### DIFF
--- a/docs/miReset.css
+++ b/docs/miReset.css
@@ -208,9 +208,7 @@ button {
 }
 
 /* Evitamos problemas con los inputs y botones de formulario */
-input[type="text"],
-input[type="email"],
-input[type="password"],
+input,
 textarea,
 button,
 select {

--- a/miReset.css
+++ b/miReset.css
@@ -208,9 +208,7 @@ button {
 }
 
 /* Evitamos problemas con los inputs y botones de formulario */
-input[type="text"],
-input[type="email"],
-input[type="password"],
+input,
 textarea,
 button,
 select {


### PR DESCRIPTION
Updated the CSS selector to target all input elements instead of only text, email, and password types. This ensures consistent reset styles across all input types.